### PR TITLE
fix(a11y): missing role=row

### DIFF
--- a/src/datepicker/datepicker-month-view.ts
+++ b/src/datepicker/datepicker-month-view.ts
@@ -10,7 +10,7 @@ import {DayTemplateContext} from './datepicker-day-template-context';
   encapsulation: ViewEncapsulation.None,
   styleUrls: ['./datepicker-month-view.scss'],
   template: `
-    <div *ngIf="showWeekdays" class="ngb-dp-week ngb-dp-weekdays bg-light">
+    <div *ngIf="showWeekdays" class="ngb-dp-week ngb-dp-weekdays bg-light" role="row">
       <div *ngIf="showWeekNumbers" class="ngb-dp-weekday ngb-dp-showweek"></div>
       <div *ngFor="let w of month.weekdays" class="ngb-dp-weekday small" role="columnheader">
         {{ i18n.getWeekdayShortName(w) }}


### PR DESCRIPTION
After the addition of ```role="columnheader"``` (https://github.com/ng-bootstrap/ng-bootstrap/pull/3343), the parent div needs role="row", just like all consecutive sibling divs

Before submitting a pull request, please make sure you have at least performed the following:

 - [x] read and followed the [CONTRIBUTING.md](https://github.com/ng-bootstrap/ng-bootstrap/blob/master/CONTRIBUTING.md) guide.
 - [x] built and tested the changes locally.
 - [] added/updated any applicable tests.
 - [] added/updated any applicable API documentation.
 - [] added/updated any applicable demos.
